### PR TITLE
Frontend/fetch functions

### DIFF
--- a/frontend/Components/Filters/FilterCategory.js
+++ b/frontend/Components/Filters/FilterCategory.js
@@ -62,7 +62,7 @@ export default function FilterCategory(props) {
     cats.map(
       (category) =>
         (props.type === 'both' ? category.datasetsCount + category.coordinationsCount : props.type === 'datasets' ? category.datasetsCount : category.coordinationsCount) > 0 && (
-          <div>
+          <div key={'mainDiv' + category.id}>
             {category.narrower.length === 0 ? (
               <CheckboxInput
                 key={category.id}

--- a/frontend/Components/Filters/FilterCategory.js
+++ b/frontend/Components/Filters/FilterCategory.js
@@ -61,44 +61,44 @@ export default function FilterCategory(props) {
   const items = (cats) =>
     cats.map(
       (category) =>
-        (props.isDataset ? category.datasetsCount : category.coordinationsCount) > 0 && (
+        (props.type === 'both' ? category.datasetsCount + category.coordinationsCount : props.type === 'datasets' ? category.datasetsCount : category.coordinationsCount) > 0 && (
           <div>
             {category.narrower.length === 0 ? (
               <CheckboxInput
                 key={category.id}
                 handleChange={handleChange}
                 id={category.id}
-                name={`${category.name} (${props.isDataset ? category.datasetsCount : category.coordinationsCount})`}
+                name={`${category.name} (${props.type === 'both' ? category.datasetsCount + category.coordinationsCount : props.type === 'datasets' ? category.datasetsCount : category.coordinationsCount})`}
               />
             ) : (
-              <div>
-                <CheckboxInput
-                  key={category.id}
-                  handleChange={handleChange}
-                  id={category.id}
-                  name={`${category.name} (${props.isDataset ? category.datasetsCount : category.coordinationsCount})`}
-                />
-                {!shownSubItems[category.id] ? (
-                  <ExpandMoreIcon
-                    key={`More${toString(category.id)}`}
-                    style={{ cursor: 'pointer' }}
-                    fontSize="small"
-                    onClick={() => toggleShownSubItems(category.id)}
+                <div>
+                  <CheckboxInput
+                    key={category.id}
+                    handleChange={handleChange}
+                    id={category.id}
+                    name={`${category.name} (${props.type === 'both' ? category.datasetsCount + category.coordinationsCount : props.type === 'datasets' ? category.datasetsCount : category.coordinationsCount})`}
                   />
-                ) : (
-                  <ExpandLessIcon
-                    key={`Less${toString(category.id)}`}
-                    style={{ cursor: 'pointer' }}
-                    fontSize="small"
-                    onClick={() => toggleShownSubItems(category.id)}
-                  />
-                )}
+                  {!shownSubItems[category.id] ? (
+                    <ExpandMoreIcon
+                      key={`More${toString(category.id)}`}
+                      style={{ cursor: 'pointer' }}
+                      fontSize="small"
+                      onClick={() => toggleShownSubItems(category.id)}
+                    />
+                  ) : (
+                      <ExpandLessIcon
+                        key={`Less${toString(category.id)}`}
+                        style={{ cursor: 'pointer' }}
+                        fontSize="small"
+                        onClick={() => toggleShownSubItems(category.id)}
+                      />
+                    )}
 
-                <div style={{ marginLeft: '2vh' }} hidden={!shownSubItems[category.id]} id={category.id}>
-                  {items(category.narrower)}
+                  <div style={{ marginLeft: '2vh' }} hidden={!shownSubItems[category.id]} id={category.id}>
+                    {items(category.narrower)}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
           </div>
         )
     );

--- a/frontend/Components/Filters/FilterPublisher.js
+++ b/frontend/Components/Filters/FilterPublisher.js
@@ -16,7 +16,6 @@ export default function FilterPublisher(props) {
   const [res, setRes] = useState({});
 
   const handleChange = (event) => {
-    props.setChanged(true);
     const newArr = addedFilters;
     newArr.push(event.target.value);
     for (let i = 0; i < newArr.length - 1; i += 1) {
@@ -82,7 +81,14 @@ export function mapResponseToPublishers(res, type) {
   // ideally, all transformations are extracted into functions, so they can be tested
   const pubs = [];
   for (let i = 0; i < res.length; i += 1) {
-    const length = res[i].datasets.length > res[i].coordinations.length ? res[i].datasets.length : res[i].coordinations.length
+    let length;
+    if (type === 'both') {
+      length = res[i].datasets.length + res[i].coordinations.length
+    }
+    else {
+      length = type === 'datasets' ? res[i].datasets.length : res[i].coordinations.length
+    }
+    // const length = res[i].datasets.length > res[i].coordinations.length ? res[i].datasets.length : res[i].coordinations.length
     length > 0 ? pubs.push([res[i].name.split(' ')[0], res[i].id, false, i, length]) : null; // are the 'false' and 'i' properties used anywhere?
   }
   return pubs;

--- a/frontend/Components/Filters/FilterPublisher.js
+++ b/frontend/Components/Filters/FilterPublisher.js
@@ -36,7 +36,7 @@ export default function FilterPublisher(props) {
   useEffect(() => {
     GetApi('https://localhost:5001/api/publishers', setRes);
 
-    const pubs = mapResponseToPublishers(res, props.isDataset);
+    const pubs = mapResponseToPublishers(res, props.type);
 
     setPublishers(pubs);
     if (res.length < 5) {
@@ -76,13 +76,13 @@ export default function FilterPublisher(props) {
   );
 }
 
-export function mapResponseToPublishers(res, isDataset) {
+export function mapResponseToPublishers(res, type) {
   // extracted from line 39 in useEffect
   // this is a transformation of data from the server, and can be unit tested
   // ideally, all transformations are extracted into functions, so they can be tested
   const pubs = [];
   for (let i = 0; i < res.length; i += 1) {
-    const length = isDataset ? res[i].datasets.length : res[i].coordinations.length;
+    const length = res[i].datasets.length > res[i].coordinations.length ? res[i].datasets.length : res[i].coordinations.length
     length > 0 ? pubs.push([res[i].name.split(' ')[0], res[i].id, false, i, length]) : null; // are the 'false' and 'i' properties used anywhere?
   }
   return pubs;

--- a/frontend/Components/Filters/FilterPublisher.js
+++ b/frontend/Components/Filters/FilterPublisher.js
@@ -47,9 +47,9 @@ export default function FilterPublisher(props) {
     .slice(0, showItems)
     .map((pub) => (
       <FormControlLabel
-        key={pub[1]}
-        control={<Checkbox value={pub[1]} onChange={handleChange} name={pub[0]} />}
-        label={`${pub[0]} (${pub[4]})`}
+        key={pub.id}
+        control={<Checkbox value={pub.id} onChange={handleChange} name={pub.name} />}
+        label={`${pub.name} (${pub.count})`}
       />
     ));
 
@@ -82,14 +82,24 @@ export function mapResponseToPublishers(res, type) {
   const pubs = [];
   for (let i = 0; i < res.length; i += 1) {
     let length;
-    if (type === 'both') {
-      length = res[i].datasets.length + res[i].coordinations.length
+    switch (type) {
+      case 'datasets':
+        length = res[i].datasets.length;
+        break;
+      case 'coordinations':
+        length = res[i].coordinations.length;
+        break;
+      case 'both':
+      default:
+        length = res[i].datasets.length + res[i].coordinations.length;
     }
-    else {
-      length = type === 'datasets' ? res[i].datasets.length : res[i].coordinations.length
+    if (length > 0) {
+      pubs.push({
+        name: res[i].name.split(' ')[0],
+        id: res[i].id,
+        count: length,
+      });
     }
-    // const length = res[i].datasets.length > res[i].coordinations.length ? res[i].datasets.length : res[i].coordinations.length
-    length > 0 ? pubs.push([res[i].name.split(' ')[0], res[i].id, false, i, length]) : null; // are the 'false' and 'i' properties used anywhere?
   }
   return pubs;
 }

--- a/frontend/Components/Search.js
+++ b/frontend/Components/Search.js
@@ -31,8 +31,10 @@ export default function Search(props) {
   const [searchQuery, setSearchQuery] = useState({});
   const classes = useStyles();
 
+  // getDatasets(page, false, searchUrl, sortType, setDatasets, 'datasets')
+
   const sendQuery = async (value) => {
-    const cancelPrevQuery = await props.getDatasets(1, true, value);
+    const cancelPrevQuery = await props.getDatasets(value);
     return cancelPrevQuery;
   };
 

--- a/frontend/Components/Search.js
+++ b/frontend/Components/Search.js
@@ -27,6 +27,8 @@ const useStyles = makeStyles((theme) => ({
 
 export default function Search(props) {
   const [query, setQuery] = useState('');
+  // La stå! Blir brukt til å cancle precious søke requests.
+  const [searchQuery, setSearchQuery] = useState({});
   const classes = useStyles();
 
   // getDatasets(page, false, searchUrl, sortType, setDatasets, 'datasets')
@@ -42,7 +44,14 @@ export default function Search(props) {
     setQuery(value);
 
     const search = _.debounce(sendQuery, 500);
-
+    // La stå! Blir brukt til å cancle precious søke requests.
+    setSearchQuery((prevSearch) => {
+      if (prevSearch.cancel) {
+        prevSearch.cancel();
+      }
+      return search;
+    });
+    console.log(searchQuery);
     search(value);
   };
 

--- a/frontend/__tests__/FilterPublisherTests.js
+++ b/frontend/__tests__/FilterPublisherTests.js
@@ -15,11 +15,11 @@ test('Publisher mapping function handles single dataset publisher correctly', ()
     },
   ];
 
-  const mapped = mapResponseToPublishers(testResponse, true);
+  const mapped = mapResponseToPublishers(testResponse, 'datasets');
   expect(mapped.length).toBe(1);
-  expect(mapped[0][0]).toBe('Eksempel'); // prop 0 is name
-  expect(mapped[0][1]).toBe(101); // prop 1 is id
-  expect(mapped[0][4]).toBe(2); // prop 4 is length
+  expect(mapped[0].name).toBe('Eksempel'); // prop 0 is name
+  expect(mapped[0].id).toBe(101); // prop 1 is id
+  expect(mapped[0].count).toBe(2); // prop 4 is length
 });
 
 test('Publisher mapping function handles single coordination publisher correctly', () => {
@@ -32,9 +32,26 @@ test('Publisher mapping function handles single coordination publisher correctly
     },
   ];
 
-  const mapped = mapResponseToPublishers(testResponse, false);
+  const mapped = mapResponseToPublishers(testResponse, 'coordinations');
   expect(mapped.length).toBe(1);
-  expect(mapped[0][0]).toBe('Eksempel');
-  expect(mapped[0][1]).toBe(101);
-  expect(mapped[0][4]).toBe(1);
+  expect(mapped[0].name).toBe('Eksempel');
+  expect(mapped[0].id).toBe(101);
+  expect(mapped[0].count).toBe(1);
+});
+
+test('Publisher mapping function handles single mixed publisher correctly', () => {
+  const testResponse = [
+    {
+      name: 'Eksempel',
+      id: 101,
+      datasets: [100, 101],
+      coordinations: [105],
+    },
+  ];
+
+  const mapped = mapResponseToPublishers(testResponse, 'both');
+  expect(mapped.length).toBe(1);
+  expect(mapped[0].name).toBe('Eksempel');
+  expect(mapped[0].id).toBe(101);
+  expect(mapped[0].count).toBe(3);
 });

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -23,7 +23,7 @@ export default function Home() {
   const router = useRouter();
 
   const host = process.env.NEXT_PUBLIC_DOTNET_HOST;
-  const [url, setUrl] = useState(`${host}/api/datasets`);
+  const [url, setUrl] = useState(`${host}/api/`);
   const [urlType, setUrlType] = useState('both');
 
   const sUrl = '?Search=';

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -23,9 +23,7 @@ export default function Home() {
   const router = useRouter();
 
   const url = 'https://localhost:5001/api/'
-
   const [urlType, setUrlType] = useState('both');
-
   const sUrl = '?Search=';
   const fUrl = '&PublisherIds=';
   const fcUrl = '&CategoryIds=';
@@ -36,24 +34,17 @@ export default function Home() {
   const [searchUrl, setSearchUrl] = useState('');
   const [filterPublishersUrl, setFilterPublishersUrl] = useState('');
   const [filterCategoriesUrl, setFilterCategoriesUrl] = useState('');
-
   const [sortType, setSortType] = useState('title_asc');
-
-
   const [page, setPage] = useState(1);
 
   const [totalItemsDatasets, setTotalItemsDatasets] = useState(0);
   const [totalItemsCoordinations, setTotalItemsCoordinations] = useState(0)
-
-  const [hasMore, setHasMore] = useState(true);
-
-  const [changedFilter, setChangedFilter] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
 
   const [datasets, setDatasets] = useState([]);
   const [coordinations, setCoordinations] = useState([]);
 
   const [loader, setLoader] = useState('Loading...');
-
 
   const fetchContent = async (value = searchUrl) => {
     if (value !== searchUrl) {
@@ -67,7 +58,7 @@ export default function Home() {
     else {
       GetApi(url + urlType + sUrl + value + fUrl + filterPublishersUrl + fcUrl + filterCategoriesUrl + pUrl + "1" + items + sortUrl + sortType, addToEmptyList)
     }
-    console.log(url + urlType + sUrl + value + fUrl + filterPublishersUrl + fcUrl + filterCategoriesUrl + pUrl + "1" + items + sortUrl + sortType)
+    console.log('Fetching from url: ' + url + urlType + sUrl + value + fUrl + filterPublishersUrl + fcUrl + filterCategoriesUrl + pUrl + "1" + items + sortUrl + sortType)
   }
 
   const addDatasets = (response) => {
@@ -76,7 +67,6 @@ export default function Home() {
     if (response.totalItems > response.items.length) {
       setHasMore(true)
     }
-    else { setHasMore(false) }
   }
 
   const addCoordinations = (response) => {
@@ -85,7 +75,6 @@ export default function Home() {
     if (response.totalItems > response.items.length) {
       setHasMore(true)
     }
-    else { setHasMore(false) }
   }
 
   const addToEmptyList = (response) => {
@@ -95,7 +84,6 @@ export default function Home() {
       if (response.totalItems > response.items.length) {
         setHasMore(true)
       }
-      else { setHasMore(false) }
     }
     else if (urlType === 'coordinations') {
       setCoordinations(response.items)
@@ -103,7 +91,6 @@ export default function Home() {
       if (response.totalItems > response.items.length) {
         setHasMore(true)
       }
-      else { setHasMore(false) }
     }
   }
 
@@ -116,31 +103,22 @@ export default function Home() {
         GetApi(url + "coordinations" + sUrl + searchUrl + fUrl + filterPublishersUrl + fcUrl + filterCategoriesUrl + pUrl + page + items + sortUrl + sortType, addCoordinationsToExisting)
       }
     }
-    else if (urlType === 'datasets') {
-      if (totalItemsDatasets >= datasets.length) {
-        GetApi(url + urlType + sUrl + searchUrl + fUrl + filterPublishersUrl + fcUrl + filterCategoriesUrl + pUrl + page + items + sortUrl + sortType, addDatasetsToExisting)
-      }
+    else if (urlType === 'datasets' && totalItemsDatasets >= datasets.length) {
+      GetApi(url + urlType + sUrl + searchUrl + fUrl + filterPublishersUrl + fcUrl + filterCategoriesUrl + pUrl + page + items + sortUrl + sortType, addDatasetsToExisting)
     }
-    else {
-      if (totalItemsCoordinations >= coordinations.length) {
-        GetApi(url + urlType + sUrl + searchUrl + fUrl + filterPublishersUrl + fcUrl + filterCategoriesUrl + pUrl + page + items + sortUrl + sortType, addCoordinationsToExisting)
-      }
+    else if (urlType === 'coordinations' && totalItemsCoordinations >= coordinations.length) {
+      GetApi(url + urlType + sUrl + searchUrl + fUrl + filterPublishersUrl + fcUrl + filterCategoriesUrl + pUrl + page + items + sortUrl + sortType, addCoordinationsToExisting)
     }
-    console.log(url + urlType + sUrl + searchUrl + fUrl + filterPublishersUrl + fcUrl + filterCategoriesUrl + pUrl + page + items + sortUrl + sortType)
+    console.log('Fetching from url: ' + url + urlType + sUrl + searchUrl + fUrl + filterPublishersUrl + fcUrl + filterCategoriesUrl + pUrl + page + items + sortUrl + sortType)
 
   }
 
   const addCoordinationsToExisting = (response) => {
-    if (totalItemsDatasets > datasets.length || totalItemsCoordinations > coordinations.length) {
-      setHasMore(true)
-    }
-    else { setHasMore(false) }
-    if (totalItemsDatasets > coordinations.length) {
+    if (totalItemsCoordinations > coordinations.length) {
       if (loader !== 'Loading...') {
         setLoader('Loading...')
       }
       if (response.totalItems > 10) {
-
         const newArr = coordinations;
         for (let i = 0; i < 10; i += 1) {
           newArr.push(response.items[i]);
@@ -153,39 +131,28 @@ export default function Home() {
   }
 
   const addDatasetsToExisting = (response) => {
-    if (totalItemsDatasets > datasets.length || totalItemsCoordinations > coordinations.length) {
-      setHasMore(true)
-    }
-    else { setHasMore(false) }
-
-
     if (totalItemsDatasets > datasets.length) {
       if (loader !== 'Loading...') {
         setLoader('Loading...')
       }
       if (response.totalItems > 10) {
-
         const newArr = datasets;
         for (let i = 0; i < 10; i += 1) {
           newArr.push(response.items[i]);
         }
         setDatasets(newArr);
-
       }
     }
     setLoader('No more items')
     setTotalItemsDatasets(response.totalItems);
-
   }
 
-
   useEffect(() => {
-    if (page !== 1 && (coordinations.length < totalItemsCoordinations || datasets.length < totalItemsDatasets)) {
+    if ((coordinations.length < totalItemsCoordinations || datasets.length < totalItemsDatasets)) {
+      setHasMore(true)
       fetchNextPage()
     }
-    console.log(page)
   }, [page])
-
 
   useEffect(() => {
     fetchContent()
@@ -197,12 +164,9 @@ export default function Home() {
       case 'datasets': { setUrlType("datasets"); }
       case 'coordinations': { setUrlType("coordinations"); }
     }
-
     setDatasets([]);
     setCoordinations([])
-
     setUrlType(value);
-
   };
 
   const onClick = (path, id) => {
@@ -212,12 +176,9 @@ export default function Home() {
   const changeSort = (type) => {
     setDatasets([]);
     setCoordinations([])
-
     setSortType(type);
     setPage(1);
-
     fetchContent()
-
   };
 
   const getSortButtons = () => {
@@ -287,16 +248,20 @@ export default function Home() {
   };
 
   const checkIsMore = () => {
-    console.log("check has more: " + totalItemsDatasets + " : " + datasets.length)
-    console.log("check has more: " + totalItemsCoordinations + " : " + coordinations.length)
     if (urlType === 'both' && (totalItemsDatasets > datasets.length || totalItemsCoordinations > coordinations.length)) {
       setPage(page + 1)
+      setHasMore(true)
     }
     else if (urlType === 'datasets' && totalItemsDatasets > datasets.length) {
       setPage(page + 1)
+      setHasMore(true)
     }
     else if (urlType === 'coordinations' && totalItemsCoordinations > coordinations.length) {
       setPage(page + 1)
+      setHasMore(true)
+    }
+    else {
+      setHasMore(false)
     }
   }
 
@@ -307,16 +272,12 @@ export default function Home() {
           <FilterPublisher
             url={filterPublishersUrl}
             setUrl={setFilterPublishersUrl}
-
             setPage={setPage}
-            changed={changedFilter}
-            setChanged={setChangedFilter}
             type={urlType}
           />
           <FilterCategory
             url={filterCategoriesUrl}
             setUrl={setFilterCategoriesUrl}
-
             type={urlType}
           />
           <FilterTag />
@@ -332,7 +293,7 @@ export default function Home() {
               functions={[setDatasets, setCoordinations]}
             />
 
-            {/* Midlertidig select bar, bør opprette et form */}
+            {/* Midlertidig select bar, bør kanskje bruke en form */}
             <FormControl variant="outlined" style={{ width: '200px' }}>
               <InputLabel id="demo-simple-select-label">Datasett / Samordning</InputLabel>
               <Select
@@ -361,36 +322,37 @@ export default function Home() {
             {urlType === 'both' ?
               <div>
                 {coordinations && coordinations != [] && <h2 style={{ marginLeft: "1.5vh", fontWeight: 'normal' }}>Samordninger: </h2>}
-                {coordinations && coordinations !== [] &&
+                {coordinations && coordinations.length !== 0 ?
                   Object.values(coordinations).map(
                     (c) =>
                       c && (
                         <CoordinationCard
-                          key={c.id}
+                          key={'coordinationBoth' + c.id}
                           id={c.id}
                           coordination={c}
                           onClick={() => onClick('/DetailedCoordination/', c.id)}
                         />
                       )
-                  )}
+                  ) : <h3 style={{ marginLeft: "1.5vh", fontWeight: 'normal' }}>Fant ingen samordninger</h3>}
                 <br />
                 {datasets && datasets != [] && <h2 style={{ marginLeft: "1.5vh", fontWeight: 'normal' }}>Datasett: </h2>}
-                {datasets && datasets !== [] &&
+                {datasets && datasets.length !== 0 ?
                   Object.values(datasets).map(
-                    (d) => d && <DatasetCard key={d.id} dataset={d} onClick={() => onClick('/DetailedDataset/', d.id)} />
-                  )}
+                    (d) => d && <DatasetCard key={'datasetBoth' + d.id} dataset={d} onClick={() => onClick('/DetailedDataset/', d.id)} />
+                  )
+                  : <h3 style={{ marginLeft: "1.5vh", fontWeight: 'normal' }}>Fant ingen datasett</h3>}
 
               </div>
               : urlType === 'datasets' && datasets && datasets !== [] ?
                 Object.values(datasets).map(
-                  (d) => d && <DatasetCard key={d.id} dataset={d} onClick={() => onClick('/DetailedDataset/', d.id)} />
+                  (d) => d && <DatasetCard key={'dataset' + d.id} dataset={d} onClick={() => onClick('/DetailedDataset/', d.id)} />
                 )
                 : urlType === 'coordinations' && coordinations && coordinations !== [] &&
                 Object.values(coordinations).map(
                   (c) =>
                     c && (
                       <CoordinationCard
-                        key={c.id}
+                        key={'coordination' + c.id}
                         id={c.id}
                         coordination={c}
                         onClick={() => onClick('/DetailedCoordination/', c.id)}
@@ -398,29 +360,6 @@ export default function Home() {
                     )
                 )
             }
-            {/*url === 'https://localhost:5001/api/datasets' ? (
-              datasets &&
-              datasets !== [] &&
-              Object.values(datasets).map(
-                (d) => d && <DatasetCard key={d.id} dataset={d} onClick={() => onClick('/DetailedDataset/', d.id)} />
-              )
-            ) : url === 'https://localhost:5001/api/coordinations' ? (
-              datasets &&
-              datasets !== [] &&
-              Object.values(datasets).map(
-                (c) =>
-                  c && (
-                    <CoordinationCard
-                      key={c.id}
-                      id={c.id}
-                      coordination={c}
-                      onClick={() => onClick('/DetailedCoordination/', c.id)}
-                    />
-                  )
-              )
-            ) : (
-                  <p>laster...</p>
-            )*/}
             {loader === 'No items found' ? <h4>Søket ga dessverre ingen treff</h4> : null}
           </InfiniteScroll>
         </Grid>


### PR DESCRIPTION
Changed the fetch logic in index:
- Can now fetch both datasets and coordinations at the same time
- Split the fetch into two functions, one for pagination/infinite scroll and one for initial fetch when searching filtering etc
- added correct number displayed in filters when both datasets and coordinations are selected