### PR TITLE
Fix huge response

### DIFF
--- a/backend/Resources/PublisherResource.cs
+++ b/backend/Resources/PublisherResource.cs
@@ -7,8 +7,8 @@ namespace OpenData.API.Resources
     {
         public int Id { get; set; }
         public string Name { get; set; }
-        public IList<DatasetResource> Datasets { get; set; } = new List<DatasetResource>();
-        public IList<Coordination> Coordinations { get; set; } = new List<Coordination>();
+        public int DatasetsCount { get; set; }
+        public int CoordinationsCount { get; set; }
 
     }
 }

--- a/frontend/Components/Filters/FilterPublisher.js
+++ b/frontend/Components/Filters/FilterPublisher.js
@@ -88,14 +88,14 @@ export function mapResponseToPublishers(res, type) {
       let count;
       switch (type) {
         case 'datasets':
-          count = entry.datasets.length;
+          count = entry.datasetsCount;
           break;
         case 'coordinations':
-          count = entry.coordinations.length;
+          count = entry.coordinationsCount;
           break;
         case 'both':
         default:
-          count = entry.datasets.length + entry.coordinations.length;
+          count = entry.datasetsCount + entry.coordinationsCount;
       }
       return {
         name: entry.name.split(' ')[0],

--- a/frontend/__tests__/FilterPublisherTests.js
+++ b/frontend/__tests__/FilterPublisherTests.js
@@ -4,17 +4,16 @@ import { mapResponseToPublishers } from '../Components/Filters/FilterPublisher';
 // using expect(variable) and any number of extensions: https://jestjs.io/docs/en/expect
 // typically .toBe(value), .not. , .toBeFalsy/Truthy(), toHaveLength(n), toHaveProperty(key, value?), toBeNull(), toContain(item), toEqual(value)
 // expect(promise).resolves.toBe(value) for promises / things that dont resolve right away
+const testResponse = [
+  {
+    name: 'Eksempel',
+    id: 101,
+    datasetsCount: 2,
+    coordinationsCount: 1,
+  },
+];
 
 test('Publisher mapping function handles single dataset publisher correctly', () => {
-  const testResponse = [
-    {
-      name: 'Eksempel',
-      id: 101,
-      datasets: [100, 101],
-      coordinations: [105],
-    },
-  ];
-
   const mapped = mapResponseToPublishers(testResponse, 'datasets');
   expect(mapped.length).toBe(1);
   expect(mapped[0].name).toBe('Eksempel');
@@ -23,15 +22,6 @@ test('Publisher mapping function handles single dataset publisher correctly', ()
 });
 
 test('Publisher mapping function handles single coordination publisher correctly', () => {
-  const testResponse = [
-    {
-      name: 'Eksempel',
-      id: 101,
-      datasets: [100, 101],
-      coordinations: [105],
-    },
-  ];
-
   const mapped = mapResponseToPublishers(testResponse, 'coordinations');
   expect(mapped.length).toBe(1);
   expect(mapped[0].name).toBe('Eksempel');
@@ -40,15 +30,6 @@ test('Publisher mapping function handles single coordination publisher correctly
 });
 
 test('Publisher mapping function handles single mixed publisher correctly', () => {
-  const testResponse = [
-    {
-      name: 'Eksempel',
-      id: 101,
-      datasets: [100, 101],
-      coordinations: [105],
-    },
-  ];
-
   const mapped = mapResponseToPublishers(testResponse, 'both');
   expect(mapped.length).toBe(1);
   expect(mapped[0].name).toBe('Eksempel');


### PR DESCRIPTION
Changed the publisher resource to only showing the count of datasets and coordinations.