### PR TITLE
Backend/gitlab todos

### DIFF
--- a/backend/Domain/Repositories/ICoordinationRepository.cs
+++ b/backend/Domain/Repositories/ICoordinationRepository.cs
@@ -11,5 +11,6 @@ namespace OpenData.API.Domain.Repositories
         Task<Coordination> FindByIdAsync(int id);
         Task<Coordination> AddAsync(Coordination coordination);
         void Update(Coordination coordination);
+        void Remove(Coordination coordination);
     }
 }

--- a/backend/External/Gitlab/Services/GitlabService.cs
+++ b/backend/External/Gitlab/Services/GitlabService.cs
@@ -3,6 +3,8 @@ using OpenData.External.Gitlab.Models;
 using System.Threading.Tasks;
 using OpenData.External.Gitlab.Services.Communication;
 using System.Net.Http;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace OpenData.External.Gitlab.Services
 {
@@ -47,7 +49,7 @@ namespace OpenData.External.Gitlab.Services
             gitlabProject.name = dataset.Title;
             gitlabProject.description = dataset.Description;
             gitlabProject.namespace_id = dataset.Publisher.GitlabGroupNamespaceId;
-            // gitlabProject.tag_list = null; // TODO: her må det gå an å gjøre noe
+            gitlabProject.tag_list = dataset.DatasetTags.Select(tag => tag.Tags.Name).ToList();
         }
 
         private void _PopulateGitlabGroupWithPublisherInformation(GitlabGroup gitlabGroup, Publisher publisher)

--- a/backend/Persistence/Repositories/CoordinationRepository.cs
+++ b/backend/Persistence/Repositories/CoordinationRepository.cs
@@ -214,5 +214,10 @@ namespace OpenData.API.Persistence.Repositories
         {
             _context.Coordinations.Update(coordination);
         }
+
+        public void Remove(Coordination coordination)
+        {
+            _context.Coordinations.Remove(coordination);
+        }
     }
 }

--- a/backend/Services/CoordinationService.cs
+++ b/backend/Services/CoordinationService.cs
@@ -91,7 +91,9 @@ namespace OpenData.API.Services
                     await _unitOfWork.CompleteAsync();
                     return new CoordinationResponse(coordination);
                 } else {
+                    // Hvis opprettelse av prosjekt i gitlab feiler bør samordningen fjernes fra databasen
                     _coordinationRepository.Remove(coordination);
+                    await _unitOfWork.CompleteAsync();
                     return new CoordinationResponse(gitlabProjectResponse.Message);
                 }
             }

--- a/backend/Services/CoordinationService.cs
+++ b/backend/Services/CoordinationService.cs
@@ -91,7 +91,7 @@ namespace OpenData.API.Services
                     await _unitOfWork.CompleteAsync();
                     return new CoordinationResponse(coordination);
                 } else {
-                    // TODO: hvis opprettelse av prosjekt i gitlab feiler bør coordination fjernes fra databasen
+                    _coordinationRepository.Remove(coordination);
                     return new CoordinationResponse(gitlabProjectResponse.Message);
                 }
             }

--- a/backend/Services/DatasetService.cs
+++ b/backend/Services/DatasetService.cs
@@ -86,16 +86,14 @@ namespace OpenData.API.Services
                 var createDatasetTask = Task.Run(async() => {
                     dataset = await _datasetRepository.AddAsync(dataset);
                     await addTags(dataset);
-                    // NOTE: TODO: (Digresjon) dette må da kunne gjøres på en annen måte?
-                    // Både med tanke på host, men også id.
-                    // Dette bør være en del av resource men ikke selve datamodellen.
+                    // NOTE: TODO: Config
                     dataset.Identifier = "https://katalog.samåpne.no/api/datasets/" + dataset.Id;
                     _datasetRepository.Update(dataset);
                     await _unitOfWork.CompleteAsync();
                     return dataset;
                 });
 
-                // NOTE: TODO: her venter jeg på at datasettet skal opprettes uten feil,
+                // NOTE: Her venter jeg på at datasettet skal opprettes uten feil,
                 // før det opprettes i gitlab, for å hindre at det eksisterer løse prosjekter
                 // i gitlab.
                 // Dette kan kanskje gjøres smoothere.
@@ -131,7 +129,9 @@ namespace OpenData.API.Services
                     await _unitOfWork.CompleteAsync();
                     return new DatasetResponse(dataset);
                 } else {
-                    // TODO: hvis opprettelse av prosjekt i gitlab feiler bør datasettet fjernes fra databasen
+                    // Hvis opprettelse av prosjekt i gitlab feiler bør datasettet fjernes fra databasen
+                    _datasetRepository.Remove(dataset);
+                    await _unitOfWork.CompleteAsync();
                     return new DatasetResponse(gitlabProjectResponse.Message);
                 }
             }

--- a/backend/Services/PublisherService.cs
+++ b/backend/Services/PublisherService.cs
@@ -53,7 +53,7 @@ namespace OpenData.API.Services
 
                 if (gitlabGroupResponse.Success) {
                     // NOTE: bruker full_path her i stedet for web_url.
-                    // full web url (med hostname) lages ved opprettelse av resource. (TODO: faktisk gjøre dette)
+                    // full web url (med hostname) lages ved opprettelse av resource.
                     publisher.GitlabGroupPath = gitlabGroupResponse.Resource.full_path;
                     publisher.GitlabGroupNamespaceId = gitlabGroupResponse.Resource.id;
 
@@ -62,7 +62,9 @@ namespace OpenData.API.Services
 
                     return new PublisherResponse(publisher);
                 } else {
-                    // TODO: hvis opprettelse av gruppe i gitlab feiler bør publisher fjernes fra databasen
+                    // Hvis opprettelse av gruppe i gitlab feiler bør publisher fjernes fra databasen
+                    _publisherRepository.Remove(publisher);
+                    await _unitOfWork.CompleteAsync();
                     return new PublisherResponse(gitlabGroupResponse.Message);
                 }
             }

--- a/frontend/pages/DetailedCoordination/[id].js
+++ b/frontend/pages/DetailedCoordination/[id].js
@@ -357,7 +357,6 @@ export default function DetailedCoordination({ data, prevPublisherId, prevUserId
       )}
 
       {/* Forespørsler om å bli med i samordningen */}
-      {/* TODO: Nå kan kommuner legge til flere datasett til samme samordning, bør dette endres? */}
       {parseInt(prevPublisherId) === coordinationData.publisher.id ? (
         <Grid style={{ padding: '3% 0 3% 0' }}>
           <h1 style={{ fontWeight: 'normal' }}>Forespørsler om å bli med i samordningen</h1>


### PR DESCRIPTION
Added tags to gitlab project.
Removed coordination if gitlab response was not success.
Removes publisher and datasets if request from gitlab failed.